### PR TITLE
Add configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.json
+node_modules/

--- a/API/index.js
+++ b/API/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const config = require('../config');
+const app = express();
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Restaurant Economy Game API' });
+});
+
+app.listen(config.apiPort, () => {
+  console.log(`API server running on port ${config.apiPort}`);
+});

--- a/DCACT/README.md
+++ b/DCACT/README.md
@@ -1,0 +1,1 @@
+# Discord Activities placeholder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 WORKDIR /app
 COPY . .
 RUN npm install --production || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18
+WORKDIR /app
+COPY . .
+RUN npm install --production || true
+CMD ["npm", "start"]

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -1,0 +1,132 @@
+# MAII-Bot Project Plan
+
+## 中文
+
+1. **專案簡介**
+   - MAII-Bot 是一個結合經濟模擬、企業經營與 RPG 元素的 Discord 機器人，透過 Slash Commands 與玩家互動。
+
+2. **核心功能**
+   - 玩家帳號建立與隱私控制
+   - 企業創建、升級與收益計算
+   - 經濟系統與交易機制
+   - 冷卻與遊戲時間模擬
+   - 管理員指令與數據同步
+   - 自動指令同步與日誌管理
+
+3. **技術架構**
+   - Node.js 與 Discord.js 開發 Bot
+   - Redis 作為快取與狀態儲存
+   - PostgreSQL + Prisma ORM 作為資料庫
+   - winston 日誌管理
+   - Docker 與 Docker Compose 部署
+   - CI/CD 自動化測試與部署
+
+4. **專案目標**
+   - 重構舊版程式碼
+   - 實作隱私設定
+   - 自動化指令同步
+   - 建立遊戲內時間與收益循環
+   - 完整錯誤日誌管理
+   - 支援多人協作
+
+5. **開發計畫與工作分工**
+   - P1：架構重構、基礎功能完成
+   - P2：隱私控制與指令同步
+   - P3：時間循環、收益計算與冷卻
+   - P4：自動化測試與錯誤監控
+   - P5：Docker 化與 CI/CD
+   - P6：後續優化與多平台擴展
+
+6. **開發流程與協作說明**
+   - 使用 GitHub 版本控管與 Issue 管理
+   - 主要分支為 main、dev
+   - 透過 Pull Request 進行代碼審查
+   - GitHub Actions 執行 CI/CD
+   - Docker Compose 部署測試與正式環境
+   - 以 FocalBoard 管理進度
+
+7. **部署說明**
+   - Docker Compose 啟動 Bot、Redis、PostgreSQL
+   - 環境變數管理機密
+   - GitHub Actions 自動部署
+   - 集中日誌輸出便於排錯
+
+8. **專案管理與文檔**
+   - CHANGELOG.md 記錄版本更新
+   - TODO.md 整理待辦事項
+   - README.md 說明架構與環境建置
+   - FocalBoard 追蹤進度
+
+9. **未來規劃**
+   - 任務與成就系統
+   - 多平台整合
+   - 監控與通知系統
+   - 擴充企業類型與經濟模型
+   - 研發系統與排行榜
+
+---
+
+## English
+
+1. **Project Introduction**
+   - MAII-Bot is a Discord bot that combines economic simulation, company management and RPG elements using Slash Commands for player interaction.
+
+2. **Core Features**
+   - Player account creation with privacy control
+   - Company creation, upgrades and profit calculation
+   - Economy and trading system
+   - Cooldown and game time simulation
+   - Admin commands with data sync
+   - Automatic command sync and log management
+
+3. **Technical Stack**
+   - Node.js and Discord.js for the bot
+   - Redis for caching and state storage
+   - PostgreSQL with Prisma ORM
+   - Logging with winston
+   - Docker and Docker Compose deployment
+   - CI/CD for automated tests and deployment
+
+4. **Project Goals**
+   - Refactor legacy code
+   - Implement privacy settings
+   - Automate command synchronization
+   - Game time and profit loops
+   - Complete error logging
+   - Support collaborative development
+
+5. **Development Phases**
+   - P1: Architecture refactor and basic features
+   - P2: Privacy controls and command sync
+   - P3: Time loop, profit calc and cooldown system
+   - P4: Automated tests and error monitoring
+   - P5: Dockerization and CI/CD
+   - P6: Optimization and multi-platform expansion
+
+6. **Workflow**
+   - GitHub for version control and issues
+   - Main and dev branches
+   - Pull Requests for code review
+   - GitHub Actions for CI/CD
+   - Docker Compose for testing and production
+   - FocalBoard for progress tracking
+
+7. **Deployment**
+   - Docker Compose launches bot, Redis and PostgreSQL
+   - Environment variables manage secrets
+   - GitHub Actions deploy new versions
+   - Centralized logs for troubleshooting
+
+8. **Documentation**
+   - CHANGELOG.md for version updates
+   - TODO.md for tasks
+   - README.md for structure and setup
+   - FocalBoard for task management
+
+9. **Future Plans**
+   - Quest and achievement systems
+   - Multi-platform integration
+   - Monitoring and notification
+   - More company types and economic models
+   - R&D system and leaderboards
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Restaurant Economy Game 餐飲系統遊戲
+
+## English
+This project aims to simulate Taiwan's economy in a restaurant management game. It is designed around a Discord bot and will support multiple platforms including web, desktop and mobile. All text should be internationalized.
+
+### Features
+- Discord bot with slash commands
+- Express API server
+- Placeholder directories for multiplatform clients
+- Docker container support (basic)
+
+### Configuration
+1. Copy `config.example.json` to `config.json` and add your Discord token.
+2. Optionally adjust the API port.
+
+## 中文
+這個專案用來模擬台灣經濟系統的餐飲管理遊戲，核心為 Discord 機器人，並計畫支援網頁、桌面與行動裝置等多平台。所有文字皆需 i18n 處理。
+
+### 特點
+- 支援 Discord bot
+- 基礎 Express API 服務
+- 多平台目錄架構
+- 整合 Docker 容器
+
+### 設定檔
+1. 複製 `config.example.json` 成 `config.json` 並填入 Discord token。
+2. 可以修改 API 端口號。

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project aims to simulate Taiwan's economy in a restaurant management game. 
 ├── API/
 ├── DCACT/
 ├── Dockerfile
+├── PROJECT_PLAN.md
 ├── README.md
 ├── TODO.md
 ├── bot/
@@ -63,6 +64,7 @@ This project aims to simulate Taiwan's economy in a restaurant management game. 
 ├── API/
 ├── DCACT/
 ├── Dockerfile
+├── PROJECT_PLAN.md
 ├── README.md
 ├── TODO.md
 ├── bot/

--- a/README.md
+++ b/README.md
@@ -9,9 +9,37 @@ This project aims to simulate Taiwan's economy in a restaurant management game. 
 - Placeholder directories for multiplatform clients
 - Docker container support (basic)
 
+### Requirements
+- Node.js 20 or later
+
 ### Configuration
 1. Copy `config.example.json` to `config.json` and add your Discord token.
 2. Optionally adjust the API port.
+
+### Project Structure
+```
+.
+├── API/
+├── DCACT/
+├── Dockerfile
+├── README.md
+├── TODO.md
+├── bot/
+│   ├── commands/
+│   ├── handler/
+│   └── utils/
+├── config.example.json
+├── config.js
+├── index.js
+├── multiplatform/
+│   ├── Darwin/
+│   ├── android/
+│   ├── iOS/
+│   ├── linux/
+│   └── windows/
+├── package.json
+└── web/
+```
 
 ## 中文
 這個專案用來模擬台灣經濟系統的餐飲管理遊戲，核心為 Discord 機器人，並計畫支援網頁、桌面與行動裝置等多平台。所有文字皆需 i18n 處理。
@@ -22,6 +50,34 @@ This project aims to simulate Taiwan's economy in a restaurant management game. 
 - 多平台目錄架構
 - 整合 Docker 容器
 
+### 系統需求
+- Node.js 20 以上版本
+
 ### 設定檔
 1. 複製 `config.example.json` 成 `config.json` 並填入 Discord token。
 2. 可以修改 API 端口號。
+
+### 專案結構
+```
+.
+├── API/
+├── DCACT/
+├── Dockerfile
+├── README.md
+├── TODO.md
+├── bot/
+│   ├── commands/
+│   ├── handler/
+│   └── utils/
+├── config.example.json
+├── config.js
+├── index.js
+├── multiplatform/
+│   ├── Darwin/
+│   ├── android/
+│   ├── iOS/
+│   ├── linux/
+│   └── windows/
+├── package.json
+└── web/
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+## English
+- [ ] Implement full economic simulation
+- [ ] Integrate with Discord Activities
+- [ ] Develop mobile and desktop clients
+- [ ] Complete i18n for all text
+
+## 中文
+- [ ] 完整的經濟模擬系統
+- [ ] 與 Discord Activities 整合
+- [ ] 開發手機與桌面端客戶端
+- [ ] 全面完成國際化

--- a/bot/commands/ping.js
+++ b/bot/commands/ping.js
@@ -1,0 +1,8 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder().setName('ping').setDescription('Replies with Pong!'),
+  async execute(interaction, locale) {
+    await interaction.reply(locale('pong'));
+  }
+};

--- a/bot/handler/commandHandler.js
+++ b/bot/handler/commandHandler.js
@@ -1,0 +1,1 @@
+// Placeholder for command handling logic

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,37 @@
+const { Client, GatewayIntentBits, Partials, Collection } = require('discord.js');
+const path = require('node:path');
+const fs = require('node:fs');
+const { loadLocale } = require('./utils/i18n');
+const config = require('../config');
+
+const client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+  partials: [Partials.Channel]
+});
+
+client.commands = new Collection();
+
+const commandsPath = path.join(__dirname, 'commands');
+fs.readdirSync(commandsPath).forEach(file => {
+  const command = require(path.join(commandsPath, file));
+  client.commands.set(command.data.name, command);
+});
+
+client.on('interactionCreate', async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+  const command = client.commands.get(interaction.commandName);
+  if (!command) return;
+  const locale = loadLocale(interaction.locale);
+  try {
+    await command.execute(interaction, locale);
+  } catch (err) {
+    console.error(err);
+    await interaction.reply({ content: 'Error executing command', ephemeral: true });
+  }
+});
+
+if (!config.discordToken) {
+  console.error('Discord token not provided in config or ENV');
+  process.exit(1);
+}
+client.login(config.discordToken);

--- a/bot/utils/i18n.js
+++ b/bot/utils/i18n.js
@@ -1,0 +1,15 @@
+const locales = {
+  en: {
+    pong: 'Pong!'
+  },
+  zh: {
+    pong: '碰！'
+  }
+};
+
+function loadLocale(locale) {
+  const lang = locale?.startsWith('zh') ? 'zh' : 'en';
+  return key => locales[lang][key] || key;
+}
+
+module.exports = { loadLocale };

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,4 @@
+{
+  "discordToken": "YOUR_BOT_TOKEN",
+  "apiPort": 3000
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+let config = { apiPort: 3000, discordToken: process.env.DISCORD_TOKEN };
+if (fs.existsSync('./config.json')) {
+  const file = JSON.parse(fs.readFileSync('./config.json', 'utf8'));
+  config = { ...config, ...file };
+}
+module.exports = config;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+// Entry point to start bot and API
+require('./API/index');
+require('./bot/index');

--- a/multiplatform/Darwin/README.md
+++ b/multiplatform/Darwin/README.md
@@ -1,0 +1,1 @@
+# Placeholder for multiplatform/Darwin

--- a/multiplatform/android/README.md
+++ b/multiplatform/android/README.md
@@ -1,0 +1,1 @@
+# Placeholder for multiplatform/android

--- a/multiplatform/iOS/README.md
+++ b/multiplatform/iOS/README.md
@@ -1,0 +1,1 @@
+# Placeholder for multiplatform/iOS

--- a/multiplatform/linux/README.md
+++ b/multiplatform/linux/README.md
@@ -1,0 +1,1 @@
+# Placeholder for multiplatform/linux

--- a/multiplatform/windows/README.md
+++ b/multiplatform/windows/README.md
@@ -1,0 +1,1 @@
+# Placeholder for multiplatform/windows

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "restaurant-economy-game",
+  "version": "0.1.0",
+  "description": "A cross-platform restaurant management game powered by a Discord bot.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "api": "node API/index.js",
+    "bot": "node bot/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "discord.js": "^14.11.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
     "api": "node API/index.js",
     "bot": "node bot/index.js"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "express": "^4.18.2",
-    "discord.js": "^14.11.0"
+    "discord.js": "^14.14.1"
   }
 }

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,1 @@
+# Web client placeholder


### PR DESCRIPTION
## Summary
- add example config and loader
- load API port and Discord token from config
- document configuration steps in README
- ignore local config.json in git

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684538a10a34832c98e3431101e5f1de