### PR TITLE
Add ESLint and Prettier with basic test

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Maii Bot
+
+This is a minimal Node.js project with ESLint and Prettier configured.
+
+## Commands
+
+- `npm run lint` – run ESLint on the project files.
+- `npm run format` – format the files using Prettier.
+- `npm test` – run the simple test script.
+
+## Project Structure
+
+```
+.
+├── eslint.config.mjs
+├── .prettierrc
+├── index.js
+├── package.json
+├── test.js
+└── README.md
+```
+
+## Detailed Structure
+
+```
+maii-bot/
+├── eslint.config.mjs
+├── .prettierrc
+├── index.js
+├── package.json
+├── test.js
+└── README.md
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,10 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    rules: {}
+  }
+];

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "maii-bot",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint \"**/*.js\"",
+    "format": "prettier --write \"**/*.{js,cjs,json,md}\"",
+    "test": "node test.js"
+  },
+  "devDependencies": {
+    "eslint": "^8.58.0",
+    "prettier": "^3.2.5"
+  },
+  "type": "module"
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,5 @@
+import assert from 'assert';
+import { add } from './index.js';
+
+assert.strictEqual(add(1, 2), 3);
+console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- configure ESLint and Prettier
- add basic `add` function and test
- document commands and file structure

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845435b09ac832cbdcef808b03a4b8a