### PR TITLE
Add docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,27 @@ This is a minimal Node.js project with ESLint and Prettier configured.
 - `npm run lint` – run ESLint on the project files.
 - `npm run format` – format the files using Prettier.
 - `npm test` – run the simple test script.
+- `docker compose up` – start the API and bot services.
+
+## Docker Compose Usage
+
+Start both services with:
+
+```sh
+docker compose up
+```
+
+The API service will be available at `http://localhost:3000`.
 
 ## Project Structure
 
 ```
 .
+├── api
+│   └── index.js
+├── bot
+│   └── index.js
+├── docker-compose.yml
 ├── eslint.config.mjs
 ├── .prettierrc
 ├── index.js
@@ -25,6 +41,11 @@ This is a minimal Node.js project with ESLint and Prettier configured.
 
 ```
 maii-bot/
+├── api
+│   └── index.js
+├── bot
+│   └── index.js
+├── docker-compose.yml
 ├── eslint.config.mjs
 ├── .prettierrc
 ├── index.js

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,13 @@
+import http from 'http';
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ message: 'API is running' }));
+});
+
+server.listen(port, () => {
+  console.log(`API server running at http://localhost:${port}`);
+});

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,3 @@
+setInterval(() => {
+  console.log('Bot service running');
+}, 60000);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  api:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: node api/index.js
+    ports:
+      - '3000:3000'
+
+  bot:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: node bot/index.js


### PR DESCRIPTION
## Summary
- add simple API and bot services
- provide docker-compose file to start both services
- document docker compose usage and update the project structure diagrams

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845483419c0832ca6d67178b6adf68d