### PR TITLE
Implement command handler and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This is a minimal Node.js project with ESLint and Prettier configured.
 .
 ├── eslint.config.mjs
 ├── .prettierrc
+├── commandHandler.js
+├── bot
+│   ├── index.js
+│   └── commands
+│       └── ping.js
 ├── index.js
 ├── package.json
 ├── test.js
@@ -27,6 +32,11 @@ This is a minimal Node.js project with ESLint and Prettier configured.
 maii-bot/
 ├── eslint.config.mjs
 ├── .prettierrc
+├── commandHandler.js
+├── bot
+│   ├── index.js
+│   └── commands
+│       └── ping.js
 ├── index.js
 ├── package.json
 ├── test.js

--- a/bot/commands/ping.js
+++ b/bot/commands/ping.js
@@ -1,0 +1,4 @@
+export const name = 'ping';
+export function execute() {
+  return 'pong';
+}

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,16 @@
+import { CommandHandler } from '../commandHandler.js';
+
+const handler = new CommandHandler();
+await handler.loadCommands(new URL('./commands/', import.meta.url));
+
+export async function runCommand(name, ...args) {
+  return handler.execute(name, ...args);
+}
+
+// Example usage if this file is run directly
+if (
+  import.meta.url === process.argv[1] ||
+  import.meta.url === `file://${process.argv[1]}`
+) {
+  handler.execute('ping').then(console.log).catch(console.error);
+}

--- a/commandHandler.js
+++ b/commandHandler.js
@@ -1,0 +1,35 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+export class CommandHandler {
+  constructor() {
+    this.commands = new Map();
+  }
+
+  async loadCommands(directory) {
+    const dirPath =
+      directory instanceof URL ? directory : path.resolve(directory);
+    const files = await fs.readdir(dirPath);
+    for (const file of files) {
+      if (!file.endsWith('.js')) continue;
+      const fileUrl =
+        directory instanceof URL
+          ? new URL(file, directory)
+          : pathToFileURL(path.join(dirPath, file));
+      const commandModule = await import(fileUrl.href);
+      const { name, execute } = commandModule;
+      if (name && typeof execute === 'function') {
+        this.commands.set(name, execute);
+      }
+    }
+  }
+
+  async execute(name, ...args) {
+    const command = this.commands.get(name);
+    if (!command) {
+      throw new Error(`Command "${name}" not found`);
+    }
+    return command(...args);
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,5 +1,12 @@
 import assert from 'assert';
 import { add } from './index.js';
+import { CommandHandler } from './commandHandler.js';
 
 assert.strictEqual(add(1, 2), 3);
+
+const handler = new CommandHandler();
+await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
+const result = await handler.execute('ping');
+assert.strictEqual(result, 'pong');
+
 console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- add basic command handler for bot commands
- add `bot` directory with a `ping` command
- use the handler in `bot/index.js`
- test command handler in `test.js`
- document new structure in README

## Testing
- `npx prettier --write "**/*.{js,cjs,json,md}"`
- `npx eslint "**/*.js"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684548362d2c832c83664695e06bcbd1