### PR TITLE
Add winston logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Maii Bot
 
-This is a minimal Node.js project with ESLint and Prettier configured.
+This is a minimal Node.js project with ESLint and Prettier configured. It uses
+[winston](https://github.com/winstonjs/winston) for logging. Logs are written to
+`logs/app.log`.
 
 ## Commands
 
@@ -14,6 +16,7 @@ This is a minimal Node.js project with ESLint and Prettier configured.
 .
 ├── eslint.config.mjs
 ├── .prettierrc
+├── logger.js
 ├── index.js
 ├── package.json
 ├── test.js
@@ -27,12 +30,17 @@ This is a minimal Node.js project with ESLint and Prettier configured.
 maii-bot/
 ├── eslint.config.mjs
 ├── .prettierrc
+├── logger.js
 ├── index.js
 ├── package.json
 ├── test.js
 ├── LICENSE
 └── README.md
 ```
+
+## Log Files
+
+Logs are stored in `logs/app.log` when the application or tests run.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+import logger from './logger.js';
+
 export function add(a, b) {
-  return a + b;
+  const result = a + b;
+  logger.info(`add called with ${a} and ${b}, returning ${result}`);
+  return result;
 }

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,18 @@
+import { createLogger, format, transports } from 'winston';
+import fs from 'fs';
+
+const logDir = 'logs';
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir);
+}
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(format.timestamp(), format.simple()),
+  transports: [
+    new transports.File({ filename: `${logDir}/app.log` }),
+    new transports.Console(),
+  ],
+});
+
+export default logger;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "format": "prettier --write \"**/*.{js,cjs,json,md}\"",
     "test": "node test.js"
   },
+  "dependencies": {
+    "winston": "^3.11.0"
+  },
   "devDependencies": {
     "eslint": "^8.58.0",
     "prettier": "^3.2.5"

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { add } from './index.js';
+import logger from './logger.js';
 
 assert.strictEqual(add(1, 2), 3);
-console.log('All tests passed!');
+logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- add winston as a dependency and create a simple logger
- log in the `add` function and tests
- update project tree and document log location in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_684548376fa4832c8cf40fb9f68e6c89