### PR TITLE
Use logger for API startup logs

### DIFF
--- a/API/index.js
+++ b/API/index.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import config from '../config.js';
+import logger from '../logger.js';
 const app = express();
 
 app.get('/', (req, res) => {
@@ -7,5 +8,5 @@ app.get('/', (req, res) => {
 });
 
 app.listen(config.apiPort, () => {
-  console.log(`API server running on port ${config.apiPort}`);
+  logger.info(`API server running on port ${config.apiPort}`);
 });

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The API service will be available at `http://localhost:3000`.
 ## Log Files
 
 Logs are stored in `logs/app.log` when the application or tests run.
+All services write messages using the centralized `logger.js` which wraps the
+`winston` library. Avoid using `console.log` in the codebase.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { add } from './index.js';
 import { CommandHandler } from './commandHandler.js';
+import logger from './logger.js';
 
 assert.strictEqual(add(1, 2), 3);
 
@@ -9,8 +10,4 @@ await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
 const result = await handler.execute('ping');
 assert.strictEqual(result, 'pong');
 
-console.log('All tests passed!');
-import logger from './logger.js';
-
-assert.strictEqual(add(1, 2), 3);
 logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- import `logger` in `API/index.js`
- log server start with `logger.info`
- switch test output from `console.log` to `logger.info`
- document the new logging convention

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_68468799c300832cbe8b2a6d2c233cae