### PR TITLE
Add command sync event

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ npm run bot
 - `npm run lint` – run ESLint on the project files.
 - `npm run format` – format the files using Prettier.
 - `npm test` – run the simple test script.
+- `npm run ci` – run lint, format, and tests together.
 - `docker compose up` – start the API and bot services.
+
+### Command Sync
+
+Use `handler.syncCommands(client)` to register all slash commands. The handler
+emits a `synced` event once the Discord API update completes.
 
 ## Docker Compose Usage
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -10,6 +10,10 @@ import logger from '../logger.js';
 const handler = new CommandHandler();
 await handler.loadCommands(new URL('./commands/', import.meta.url));
 
+handler.on('synced', () => {
+  logger.info('Slash commands synced');
+});
+
 export async function runCommand(name, ...args) {
   return handler.execute(name, ...args);
 }
@@ -46,6 +50,10 @@ const __dirname = path.dirname(__filename);
 const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
   partials: [Partials.Channel],
+});
+
+client.once('ready', async () => {
+  await handler.syncCommands(client);
 });
 
 client.commands = new Collection();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "bot": "node bot/index.js",
     "lint": "eslint \"**/*.js\"",
     "format": "prettier --write \"**/*.{js,cjs,json,md}\"",
-    "test": "node test.js"
+    "test": "node test.js",
+    "ci": "npm run lint && npm run format && npm test"
   },
   "engines": {
     "node": ">=20"

--- a/test.js
+++ b/test.js
@@ -10,4 +10,14 @@ await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
 const result = await handler.execute('ping');
 assert.strictEqual(result, 'pong');
 
+let synced = false;
+handler.on('synced', () => {
+  synced = true;
+});
+
+await handler.syncCommands({
+  application: { commands: { set: async () => [] } },
+});
+assert.strictEqual(synced, true);
+
 logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- emit an event when command handler syncs slash commands
- sync all slash commands when Discord bot is ready
- expose a manual `npm run ci` script for lint/format/test
- explain command sync in README

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_68477e5bd428832ca209e8e47cf66419