### PR TITLE
Remove interval log

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -25,9 +25,6 @@ if (
 ) {
   handler.execute('ping').then(console.log).catch(console.error);
 }
-setInterval(() => {
-  console.log('Bot service running');
-}, 60000);
 
 const originalFetch = global.fetch;
 global.fetch = async (...args) => {
@@ -53,6 +50,7 @@ const client = new Client({
 });
 
 client.once('ready', async () => {
+  logger.info(`Logged in as ${client.user.tag}`);
   await handler.syncCommands(client);
 });
 


### PR DESCRIPTION
## Summary
- remove the keep-alive `setInterval` from the bot
- log startup with `winston` when Discord client is ready

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_68493c2ab784832c9f64597c03f8f360