### PR TITLE
Implement CI exit for Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Run the Discord bot:
 npm run bot
 ```
 
+Run the Discord bot in CI:
+
+```bash
+npm run bot:ci
+```
+
 ## Project Structure
 
 ```

--- a/bot/index.js
+++ b/bot/index.js
@@ -52,6 +52,11 @@ const client = new Client({
 client.once('ready', async () => {
   logger.info(`Logged in as ${client.user.tag}`);
   await handler.syncCommands(client);
+  if (process.env.CI) {
+    logger.info('CI environment detected, shutting down.');
+    await client.destroy();
+    process.exit(0);
+  }
 });
 
 client.commands = new Collection();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node index.js",
     "api": "node API/index.js",
     "bot": "node bot/index.js",
+    "bot:ci": "CI=true node bot/index.js",
     "lint": "eslint \"**/*.js\"",
     "format": "prettier --write \"**/*.{js,cjs,json,md}\"",
     "test": "node test.js",


### PR DESCRIPTION
## Summary
- terminate bot after slash commands sync when `CI` variable is set
- add `bot:ci` script for running in CI
- document the new script in README

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*
- `npm install` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684943b09eb4832c8a4a11004f6391d2