### PR TITLE
Implement basic TWD economy system

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ npm run bot:ci
 ├── CHANGELOG.md
 ├── DCACT/
 ├── Dockerfile
+├── economy/
+│   ├── account.js
+│   └── currency.js
 ├── README.md
 ├── TODO.md
 ├── bot/

--- a/bot/commands/balance.js
+++ b/bot/commands/balance.js
@@ -1,0 +1,24 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { getBalance } from '../../economy/account.js';
+import { format } from '../../economy/currency.js';
+
+export const name = 'balance';
+
+export function execute(id) {
+  return getBalance(id);
+}
+
+export const slashCommand = {
+  data: new SlashCommandBuilder()
+    .setName('balance')
+    .setDescription('Check your account balance'),
+  async execute(interaction, locale) {
+    const balance = getBalance(interaction.user.id);
+    const text = locale('balance');
+    const message =
+      typeof text === 'function'
+        ? text(format(balance))
+        : `${text} ${format(balance)}`;
+    await interaction.reply(message);
+  },
+};

--- a/bot/utils/i18n.js
+++ b/bot/utils/i18n.js
@@ -1,9 +1,11 @@
 const locales = {
   en: {
     pong: 'Pong!',
+    balance: (amount) => `Balance: ${amount}`,
   },
   zh: {
     pong: '碰！',
+    balance: (amount) => `餘額：${amount}`,
   },
 };
 

--- a/economy/account.js
+++ b/economy/account.js
@@ -1,0 +1,28 @@
+const accounts = new Map();
+
+export function getBalance(id) {
+  return accounts.get(id) ?? 0;
+}
+
+export function deposit(id, amount) {
+  if (amount <= 0) return getBalance(id);
+  accounts.set(id, getBalance(id) + amount);
+  return getBalance(id);
+}
+
+export function withdraw(id, amount) {
+  const balance = getBalance(id);
+  if (amount > balance) {
+    throw new Error('Insufficient funds');
+  }
+  accounts.set(id, balance - amount);
+  return getBalance(id);
+}
+
+export function reset(id) {
+  if (id) {
+    accounts.delete(id);
+  } else {
+    accounts.clear();
+  }
+}

--- a/economy/currency.js
+++ b/economy/currency.js
@@ -1,0 +1,10 @@
+export const currency = {
+  code: 'TWD',
+  name: 'New Taiwan Dollar',
+  symbol: 'NT$',
+  decimals: 0,
+};
+
+export function format(amount) {
+  return `${currency.symbol}${amount.toFixed(currency.decimals)}`;
+}

--- a/test.js
+++ b/test.js
@@ -2,6 +2,8 @@ import assert from 'assert';
 import { add } from './index.js';
 import { CommandHandler } from './commandHandler.js';
 import logger from './logger.js';
+import { deposit, withdraw, getBalance, reset } from './economy/account.js';
+import { format } from './economy/currency.js';
 
 assert.strictEqual(add(1, 2), 3);
 
@@ -19,5 +21,14 @@ await handler.syncCommands({
   application: { commands: { set: async () => [] } },
 });
 assert.strictEqual(synced, true);
+
+// Economy tests
+reset();
+deposit('test', 100);
+assert.strictEqual(getBalance('test'), 100);
+withdraw('test', 40);
+assert.strictEqual(getBalance('test'), 60);
+assert.throws(() => withdraw('test', 100));
+assert.strictEqual(format(60), 'NT$60');
 
 logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- add economy modules for currency and accounts
- create `/balance` slash command
- support balance message in i18n
- extend tests for economy logic
- update project structure in README

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_684a4dcfed48832c85cec03a3db760ca