### PR TITLE
修正 account 模組重複定義

### DIFF
--- a/economy/account.js
+++ b/economy/account.js
@@ -14,10 +14,6 @@ export function getBalance(id) {
   accounts.set(id, value);
   cache.set(id, value);
   return value;
-const accounts = new Map();
-
-export function getBalance(id) {
-  return accounts.get(id) ?? 0;
 }
 
 export function deposit(id, amount) {
@@ -27,8 +23,6 @@ export function deposit(id, amount) {
   cache.set(id, newBalance);
   db.updatePlayer(id, newBalance);
   return newBalance;
-  accounts.set(id, getBalance(id) + amount);
-  return getBalance(id);
 }
 
 export function withdraw(id, amount) {
@@ -50,8 +44,6 @@ export function initAccount(id) {
     cache.set(id, 0);
   }
   return created;
-  accounts.set(id, balance - amount);
-  return getBalance(id);
 }
 
 export function reset(id) {
@@ -63,7 +55,5 @@ export function reset(id) {
     accounts.clear();
     cache.reset();
     db.reset();
-  } else {
-    accounts.clear();
   }
 }

--- a/test.js
+++ b/test.js
@@ -9,7 +9,6 @@ import {
   reset,
   initAccount,
 } from './economy/account.js';
-import { deposit, withdraw, getBalance, reset } from './economy/account.js';
 import { format } from './economy/currency.js';
 
 assert.strictEqual(add(1, 2), 3);


### PR DESCRIPTION
## Summary
- 移除 `economy/account.js` 中重複的程式區塊並補齊括號
- 清理 `test.js` 重複的 import

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(失敗：缺少 winston 套件)*

------
https://chatgpt.com/codex/tasks/task_e_684bbbed4b18832c8a18abf05fbec7f3