### PR TITLE
Fix conditional imports in entry point

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 import logger from './logger.js';
-import './API/index.js';
-import './bot/index.js';
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await import('./API/index.js');
+  await import('./bot/index.js');
+}
 
 export function add(a, b) {
   const result = a + b;


### PR DESCRIPTION
## Summary
- avoid importing API and bot modules unless `index.js` is run directly

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bbd51d0ec832c84a8a742f7aeb9b3