### PR TITLE
Add kanban command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ npm run bot:ci
 │   ├── iOS/
 │   ├── linux/
 │   └── windows/
+├── src/
+│   └── kanban/
 ├── package-lock.json
 ├── package.json
 ├── test.js

--- a/bot/commands/kanban.js
+++ b/bot/commands/kanban.js
@@ -1,0 +1,35 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { addCard } from '../../src/kanban/index.js';
+
+export const name = 'kanbanadd';
+
+export function execute(text, assign) {
+  return addCard(text, assign);
+}
+
+export const slashCommand = {
+  data: new SlashCommandBuilder()
+    .setName('kanban')
+    .setDescription('看板操作')
+    .addSubcommand((cmd) =>
+      cmd
+        .setName('add')
+        .setDescription('新增卡片')
+        .addStringOption((o) =>
+          o.setName('text').setDescription('內容').setRequired(true),
+        )
+        .addStringOption((o) =>
+          o.setName('assign').setDescription('指派給').setRequired(true),
+        ),
+    ),
+  async execute(interaction) {
+    if (interaction.options.getSubcommand() !== 'add') {
+      await interaction.reply('未知指令');
+      return;
+    }
+    const text = interaction.options.getString('text');
+    const assign = interaction.options.getString('assign');
+    const result = addCard(text, assign);
+    await interaction.reply(JSON.stringify(result));
+  },
+};

--- a/src/kanban/index.js
+++ b/src/kanban/index.js
@@ -1,0 +1,3 @@
+export function addCard(text, assign) {
+  return { text, assign };
+}

--- a/test.js
+++ b/test.js
@@ -10,34 +10,83 @@ import {
   initAccount,
 } from './bot/handler/ecom/account.js';
 import { format } from './bot/handler/ecom/currency.js';
+import { addCard } from './src/kanban/index.js';
 
-assert.strictEqual(add(1, 2), 3);
+function test(name, fn) {
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      result
+        .then(() => console.log(`✓ ${name}`))
+        .catch((err) => {
+          console.error(`✕ ${name}`);
+          console.error(err);
+          process.exitCode = 1;
+        });
+    } else {
+      console.log(`✓ ${name}`);
+    }
+  } catch (err) {
+    console.error(`✕ ${name}`);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+function expect(actual) {
+  return {
+    toBe(expected) {
+      assert.strictEqual(actual, expected);
+    },
+    toEqual(expected) {
+      assert.deepStrictEqual(actual, expected);
+    },
+  };
+}
 
 const handler = new CommandHandler();
 await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
 await handler.loadCommands(new URL('./bot/commands/ecom/', import.meta.url));
-const result = await handler.execute('ping');
-assert.strictEqual(result, 'pong');
 
-let synced = false;
-handler.on('synced', () => {
-  synced = true;
+test('add function', () => {
+  expect(add(1, 2)).toBe(3);
 });
 
-await handler.syncCommands({
-  application: { commands: { set: async () => [] } },
+test('ping command', async () => {
+  const result = await handler.execute('ping');
+  expect(result).toBe('pong');
 });
-assert.strictEqual(synced, true);
 
-// Economy tests
-reset();
-assert.strictEqual(initAccount('test'), true);
-assert.strictEqual(initAccount('test'), false);
-deposit('test', 100);
-assert.strictEqual(getBalance('test'), 100);
-withdraw('test', 40);
-assert.strictEqual(getBalance('test'), 60);
-assert.throws(() => withdraw('test', 100));
-assert.strictEqual(format(60), 'NT$60');
+test('sync commands event', async () => {
+  let synced = false;
+  handler.on('synced', () => {
+    synced = true;
+  });
+  await handler.syncCommands({
+    application: { commands: { set: async () => [] } },
+  });
+  expect(synced).toBe(true);
+});
+
+test('economy functions', () => {
+  reset();
+  expect(initAccount('test')).toBe(true);
+  expect(initAccount('test')).toBe(false);
+  deposit('test', 100);
+  expect(getBalance('test')).toBe(100);
+  withdraw('test', 40);
+  expect(getBalance('test')).toBe(60);
+  assert.throws(() => withdraw('test', 100));
+  expect(format(60)).toBe('NT$60');
+});
+
+test('kanban add', () => {
+  expect(addCard('123', 'test')).toEqual({ text: '123', assign: 'test' });
+});
+
+test('kanban command', async () => {
+  const result = await handler.execute('kanbanadd', '123', 'test');
+  expect(result).toEqual({ text: '123', assign: 'test' });
+});
 
 logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- implement `addCard` in `src/kanban`
- create `/kanban add` command
- expand test.js with a small Jest-like stub
- document new `src/kanban` folder in the project tree

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_684de9b6ace4832ca8f1f8ba070bbb93