### PR TITLE
Replace console logging with logger

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -24,7 +24,7 @@ if (
   import.meta.url === process.argv[1] ||
   import.meta.url === `file://${process.argv[1]}`
 ) {
-  handler.execute('ping').then(console.log).catch(console.error);
+  handler.execute('ping').then(logger.info).catch(logger.error);
 }
 
 const originalFetch = global.fetch;
@@ -79,7 +79,7 @@ client.on('interactionCreate', async (interaction) => {
   try {
     await command.execute(interaction, locale);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     await interaction.reply({
       content: 'Error executing command',
       ephemeral: true,
@@ -88,7 +88,7 @@ client.on('interactionCreate', async (interaction) => {
 });
 
 if (!config.discordToken) {
-  console.error('Discord token not provided in config or ENV');
+  logger.error('Discord token not provided in config or ENV');
   process.exit(1);
 }
 client.login(config.discordToken);

--- a/test.js
+++ b/test.js
@@ -17,18 +17,18 @@ function test(name, fn) {
     const result = fn();
     if (result instanceof Promise) {
       result
-        .then(() => console.log(`✓ ${name}`))
+        .then(() => logger.info(`✓ ${name}`))
         .catch((err) => {
-          console.error(`✕ ${name}`);
-          console.error(err);
+          logger.error(`✕ ${name}`);
+          logger.error(err);
           process.exitCode = 1;
         });
     } else {
-      console.log(`✓ ${name}`);
+      logger.info(`✓ ${name}`);
     }
   } catch (err) {
-    console.error(`✕ ${name}`);
-    console.error(err);
+    logger.error(`✕ ${name}`);
+    logger.error(err);
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary
- switch to `logger.info`/`logger.error` in tests
- use logger in bot startup code

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_684df24c553c832cb9f11c2b1f4daafc