### PR TITLE
Fix withdraw negative amounts

### DIFF
--- a/bot/handler/ecom/account.js
+++ b/bot/handler/ecom/account.js
@@ -26,6 +26,9 @@ export function deposit(id, amount) {
 }
 
 export function withdraw(id, amount) {
+  if (amount <= 0) {
+    throw new Error('Invalid amount');
+  }
   const balance = getBalance(id);
   if (amount > balance) {
     throw new Error('Insufficient funds');

--- a/test.js
+++ b/test.js
@@ -80,6 +80,14 @@ test('economy functions', () => {
   expect(format(60)).toBe('NT$60');
 });
 
+test('withdraw negative amount', () => {
+  reset();
+  initAccount('neg');
+  deposit('neg', 50);
+  assert.throws(() => withdraw('neg', -10));
+  expect(getBalance('neg')).toBe(50);
+});
+
 test('kanban add', () => {
   expect(addCard('123', 'test')).toEqual({ text: '123', assign: 'test' });
 });


### PR DESCRIPTION
## Summary
- throw error on negative withdraw amounts
- update test to expect an error

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df7766a38832ca3d42b5763d07b27