### PR TITLE
Add error execute locale

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -81,7 +81,7 @@ client.on('interactionCreate', async (interaction) => {
   } catch (err) {
     logger.error(err);
     await interaction.reply({
-      content: 'Error executing command',
+      content: locale('error_execute'),
       ephemeral: true,
     });
   }

--- a/bot/utils/i18n.js
+++ b/bot/utils/i18n.js
@@ -4,12 +4,14 @@ const locales = {
     balance: (amount) => `Balance: ${amount}`,
     init_success: 'Player created',
     init_exists: 'Player already exists',
+    error_execute: 'Error executing command',
   },
   zh: {
     pong: '碰！',
     balance: (amount) => `餘額：${amount}`,
     init_success: '玩家已建立',
     init_exists: '玩家已存在',
+    error_execute: '執行指令時發生錯誤',
   },
 };
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { add } from './index.js';
 import { CommandHandler } from './bot/handler/commandHandler.js';
 import logger from './logger.js';
+import { loadLocale } from './bot/utils/i18n.js';
 import {
   deposit,
   withdraw,
@@ -95,6 +96,13 @@ test('kanban add', () => {
 test('kanban command', async () => {
   const result = await handler.execute('kanbanadd', '123', 'test');
   expect(result).toEqual({ text: '123', assign: 'test' });
+});
+
+test('locale error_execute', () => {
+  const en = loadLocale('en');
+  const zh = loadLocale('zh-TW');
+  expect(en('error_execute')).toBe('Error executing command');
+  expect(zh('error_execute')).toBe('執行指令時發生錯誤');
 });
 
 logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- add `error_execute` key in locale maps
- swap hardcoded error message with localized string
- test the new localization

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df98d4a34832c9f2ee60ca9ac49f8