### PR TITLE
Switch to JSON-based i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ npm run bot:ci
 │   ├── handler/
 │   │   ├── commandHandler.js
 │   │   └── ecom/
+│   ├── lang/
+│   │   ├── en.json
+│   │   ├── ja.json
+│   │   └── zh.json
 │   └── utils/
 │       └── i18n.js
 ├── config.example.json

--- a/bot/commands/ecom/balance.js
+++ b/bot/commands/ecom/balance.js
@@ -14,11 +14,6 @@ export const slashCommand = {
     .setDescription('Check your account balance'),
   async execute(interaction, locale) {
     const balance = getBalance(interaction.user.id);
-    const text = locale('balance');
-    const message =
-      typeof text === 'function'
-        ? text(format(balance))
-        : `${text} ${format(balance)}`;
-    await interaction.reply(message);
+    await interaction.reply(locale('balance', { amount: format(balance) }));
   },
 };

--- a/bot/lang/en.json
+++ b/bot/lang/en.json
@@ -1,0 +1,6 @@
+{
+  "pong": "Pong!",
+  "balance": "Balance: {amount}",
+  "init_success": "Player created",
+  "init_exists": "Player already exists"
+}

--- a/bot/lang/ja.json
+++ b/bot/lang/ja.json
@@ -1,0 +1,6 @@
+{
+  "pong": "ポン！",
+  "balance": "残高：{amount}",
+  "init_success": "プレイヤーが作成されました",
+  "init_exists": "プレイヤーは既に存在します"
+}

--- a/bot/lang/zh.json
+++ b/bot/lang/zh.json
@@ -1,0 +1,6 @@
+{
+  "pong": "碰！",
+  "balance": "餘額：{amount}",
+  "init_success": "玩家已建立",
+  "init_exists": "玩家已存在"
+}

--- a/bot/utils/i18n.js
+++ b/bot/utils/i18n.js
@@ -1,19 +1,24 @@
-const locales = {
-  en: {
-    pong: 'Pong!',
-    balance: (amount) => `Balance: ${amount}`,
-    init_success: 'Player created',
-    init_exists: 'Player already exists',
-  },
-  zh: {
-    pong: '碰！',
-    balance: (amount) => `餘額：${amount}`,
-    init_success: '玩家已建立',
-    init_exists: '玩家已存在',
-  },
-};
+import fs from 'node:fs';
+
+const langDir = new URL('../lang/', import.meta.url);
+const cache = {};
 
 export function loadLocale(locale) {
-  const lang = locale?.startsWith('zh') ? 'zh' : 'en';
-  return (key) => locales[lang][key] || key;
+  const lang = locale?.startsWith('zh')
+    ? 'zh'
+    : locale?.startsWith('ja')
+      ? 'ja'
+      : 'en';
+  if (!cache[lang]) {
+    const file = new URL(`${lang}.json`, langDir);
+    try {
+      cache[lang] = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      cache[lang] = {};
+    }
+  }
+  return (key, vars = {}) => {
+    const template = cache[lang][key] || key;
+    return template.replace(/\{(\w+)\}/g, (_, k) => vars[k] ?? `{${k}}`);
+  };
 }

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { add } from './index.js';
 import { CommandHandler } from './bot/handler/commandHandler.js';
 import logger from './logger.js';
+import { loadLocale } from './bot/utils/i18n.js';
 import {
   deposit,
   withdraw,
@@ -95,6 +96,12 @@ test('kanban add', () => {
 test('kanban command', async () => {
   const result = await handler.execute('kanbanadd', '123', 'test');
   expect(result).toEqual({ text: '123', assign: 'test' });
+});
+
+test('i18n translations', () => {
+  const t = loadLocale('ja');
+  expect(t('pong')).toBe('ポン！');
+  expect(t('balance', { amount: '100' })).toBe('残高：100');
 });
 
 logger.info('All tests passed!');


### PR DESCRIPTION
## Summary
- move locale strings into `bot/lang/*.json`
- load locale data from JSON files in `loadLocale`
- simplify balance command localization
- add Japanese translations
- cover i18n in tests
- document new `bot/lang/` folder in project tree

## Testing
- `npm run lint`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dfa5bc978832c8553b3515223e565