### PR TITLE
Fix command loader recursion

### DIFF
--- a/bot/handler/commandHandler.js
+++ b/bot/handler/commandHandler.js
@@ -13,13 +13,21 @@ export class CommandHandler extends EventEmitter {
   async loadCommands(directory) {
     const dirPath =
       directory instanceof URL ? directory : path.resolve(directory);
-    const files = await fs.readdir(dirPath);
-    for (const file of files) {
-      if (!file.endsWith('.js')) continue;
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const subDir =
+          directory instanceof URL
+            ? new URL(`${entry.name}/`, directory)
+            : path.join(dirPath, entry.name);
+        await this.loadCommands(subDir);
+        continue;
+      }
+      if (!entry.name.endsWith('.js')) continue;
       const fileUrl =
         directory instanceof URL
-          ? new URL(file, directory)
-          : pathToFileURL(path.join(dirPath, file));
+          ? new URL(entry.name, directory)
+          : pathToFileURL(path.join(dirPath, entry.name));
       const commandModule = await import(fileUrl.href);
       const { name, execute, slashCommand } = commandModule;
       if (name && typeof execute === 'function') {

--- a/bot/index.js
+++ b/bot/index.js
@@ -9,7 +9,6 @@ import logger from '../logger.js';
 
 const handler = new CommandHandler();
 await handler.loadCommands(new URL('./commands/', import.meta.url));
-await handler.loadCommands(new URL('./commands/ecom/', import.meta.url));
 
 handler.on('synced', () => {
   logger.info('Slash commands synced');

--- a/test.js
+++ b/test.js
@@ -47,7 +47,6 @@ function expect(actual) {
 
 const handler = new CommandHandler();
 await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
-await handler.loadCommands(new URL('./bot/commands/ecom/', import.meta.url));
 
 test('add function', () => {
   expect(add(1, 2)).toBe(3);

--- a/test.js
+++ b/test.js
@@ -46,62 +46,65 @@ function expect(actual) {
 }
 
 const handler = new CommandHandler();
-await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
 
-test('add function', () => {
-  expect(add(1, 2)).toBe(3);
-});
+(async () => {
+  await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
 
-test('ping command', async () => {
-  const result = await handler.execute('ping');
-  expect(result).toBe('pong');
-});
-
-test('sync commands event', async () => {
-  let synced = false;
-  handler.on('synced', () => {
-    synced = true;
+  test('add function', () => {
+    expect(add(1, 2)).toBe(3);
   });
-  await handler.syncCommands({
-    application: { commands: { set: async () => [] } },
+
+  test('ping command', async () => {
+    const result = await handler.execute('ping');
+    expect(result).toBe('pong');
   });
-  expect(synced).toBe(true);
-});
 
-test('economy functions', () => {
-  reset();
-  expect(initAccount('test')).toBe(true);
-  expect(initAccount('test')).toBe(false);
-  deposit('test', 100);
-  expect(getBalance('test')).toBe(100);
-  withdraw('test', 40);
-  expect(getBalance('test')).toBe(60);
-  assert.throws(() => withdraw('test', 100));
-  expect(format(60)).toBe('NT$60');
-});
+  test('sync commands event', async () => {
+    let synced = false;
+    handler.on('synced', () => {
+      synced = true;
+    });
+    await handler.syncCommands({
+      application: { commands: { set: async () => [] } },
+    });
+    expect(synced).toBe(true);
+  });
 
-test('withdraw negative amount', () => {
-  reset();
-  initAccount('neg');
-  deposit('neg', 50);
-  assert.throws(() => withdraw('neg', -10));
-  expect(getBalance('neg')).toBe(50);
-});
+  test('economy functions', () => {
+    reset();
+    expect(initAccount('test')).toBe(true);
+    expect(initAccount('test')).toBe(false);
+    deposit('test', 100);
+    expect(getBalance('test')).toBe(100);
+    withdraw('test', 40);
+    expect(getBalance('test')).toBe(60);
+    assert.throws(() => withdraw('test', 100));
+    expect(format(60)).toBe('NT$60');
+  });
 
-test('kanban add', () => {
-  expect(addCard('123', 'test')).toEqual({ text: '123', assign: 'test' });
-});
+  test('withdraw negative amount', () => {
+    reset();
+    initAccount('neg');
+    deposit('neg', 50);
+    assert.throws(() => withdraw('neg', -10));
+    expect(getBalance('neg')).toBe(50);
+  });
 
-test('kanban command', async () => {
-  const result = await handler.execute('kanbanadd', '123', 'test');
-  expect(result).toEqual({ text: '123', assign: 'test' });
-});
+  test('kanban add', () => {
+    expect(addCard('123', 'test')).toEqual({ text: '123', assign: 'test' });
+  });
 
-test('locale error_execute', () => {
-  const en = loadLocale('en');
-  const zh = loadLocale('zh-TW');
-  expect(en('error_execute')).toBe('Error executing command');
-  expect(zh('error_execute')).toBe('執行指令時發生錯誤');
-});
+  test('kanban command', async () => {
+    const result = await handler.execute('kanbanadd', '123', 'test');
+    expect(result).toEqual({ text: '123', assign: 'test' });
+  });
 
-logger.info('All tests passed!');
+  test('locale error_execute', () => {
+    const en = loadLocale('en');
+    const zh = loadLocale('zh-TW');
+    expect(en('error_execute')).toBe('Error executing command');
+    expect(zh('error_execute')).toBe('執行指令時發生錯誤');
+  });
+
+  logger.info('All tests passed!');
+})();


### PR DESCRIPTION
## Summary
- poll commands directories recursively
- load commands only once in bot and tests

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dfcf7a00c832c84bbd138e8468a89