### PR TITLE
Handle offline mode in bot:ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ Run the Discord bot:
 npm run bot
 ```
 
-Run the Discord bot in CI:
+Run the Discord bot in CI (offline mode):
 
 ```bash
 npm run bot:ci
 ```
+
+The CI script fetches the bot user via the Discord API. If the request fails,
+it skips login and only verifies that commands load and sync locally.
 
 ## Project Structure
 
@@ -59,11 +62,15 @@ npm run bot:ci
 ├── bot/
 │   ├── commands/
 │   │   ├── ecom/
+│   │   │   ├── balance.js
+│   │   │   └── initplayer.js
 │   │   ├── kanban.js
 │   │   └── ping.js
 │   ├── handler/
-│   │   ├── commandHandler.js
+│   │   ├── slashHandler.js
 │   │   └── ecom/
+│   │       ├── account.js
+│   │       └── currency.js
 │   └── utils/
 │       └── i18n.js
 ├── config.example.json

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,15 +1,11 @@
-import { CommandHandler } from './handler/commandHandler.js';
+import { SlashHandler } from './handler/slashHandler.js';
 import { Client, GatewayIntentBits, Partials, Collection } from 'discord.js';
-import path from 'node:path';
-import fs from 'node:fs';
-import { fileURLToPath } from 'url';
 import { loadLocale } from './utils/i18n.js';
 import config from '../config.js';
 import logger from '../logger.js';
 
-const handler = new CommandHandler();
+const handler = new SlashHandler();
 await handler.loadCommands(new URL('./commands/', import.meta.url));
-await handler.loadCommands(new URL('./commands/ecom/', import.meta.url));
 
 handler.on('synced', () => {
   logger.info('Slash commands synced');
@@ -42,9 +38,6 @@ global.fetch = async (...args) => {
   return response;
 };
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
   partials: [Partials.Channel],
@@ -62,12 +55,9 @@ client.once('ready', async () => {
 
 client.commands = new Collection();
 
-const commandsPath = path.join(__dirname, 'commands');
-for (const file of fs.readdirSync(commandsPath)) {
-  const command = await import(path.join(commandsPath, file));
-  const cmd = command.slashCommand || command.default || command;
-  if (cmd?.data?.name) {
-    client.commands.set(cmd.data.name, cmd);
+for (const slash of handler.slashCommands) {
+  if (slash?.data?.name) {
+    client.commands.set(slash.data.name, slash);
   }
 }
 
@@ -87,8 +77,35 @@ client.on('interactionCreate', async (interaction) => {
   }
 });
 
+async function networkAvailable(token) {
+  if (!token) return false;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch('https://discord.com/api/v10/users/@me', {
+      headers: { Authorization: `Bot ${token}` },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 if (!config.discordToken) {
   logger.error('Discord token not provided in config or ENV');
   process.exit(1);
+}
+
+if (process.env.CI) {
+  if (!(await networkAvailable(config.discordToken))) {
+    logger.info('Network unreachable, running in offline mode.');
+    await handler.syncCommands({
+      application: { commands: { set: async () => [] } },
+    });
+    process.exit(0);
+  }
+  logger.info('Network detected, proceeding with Discord login.');
 }
 client.login(config.discordToken);

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { add } from './index.js';
-import { CommandHandler } from './bot/handler/commandHandler.js';
+import { SlashHandler } from './bot/handler/slashHandler.js';
 import logger from './logger.js';
 import { loadLocale } from './bot/utils/i18n.js';
 import {
@@ -45,64 +45,66 @@ function expect(actual) {
   };
 }
 
-const handler = new CommandHandler();
-await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
-await handler.loadCommands(new URL('./bot/commands/ecom/', import.meta.url));
+const handler = new SlashHandler();
 
-test('add function', () => {
-  expect(add(1, 2)).toBe(3);
-});
+(async () => {
+  await handler.loadCommands(new URL('./bot/commands/', import.meta.url));
 
-test('ping command', async () => {
-  const result = await handler.execute('ping');
-  expect(result).toBe('pong');
-});
-
-test('sync commands event', async () => {
-  let synced = false;
-  handler.on('synced', () => {
-    synced = true;
+  test('add function', () => {
+    expect(add(1, 2)).toBe(3);
   });
-  await handler.syncCommands({
-    application: { commands: { set: async () => [] } },
+
+  test('ping command', async () => {
+    const result = await handler.execute('ping');
+    expect(result).toBe('pong');
   });
-  expect(synced).toBe(true);
-});
 
-test('economy functions', () => {
-  reset();
-  expect(initAccount('test')).toBe(true);
-  expect(initAccount('test')).toBe(false);
-  deposit('test', 100);
-  expect(getBalance('test')).toBe(100);
-  withdraw('test', 40);
-  expect(getBalance('test')).toBe(60);
-  assert.throws(() => withdraw('test', 100));
-  expect(format(60)).toBe('NT$60');
-});
+  test('sync commands event', async () => {
+    let synced = false;
+    handler.on('synced', () => {
+      synced = true;
+    });
+    await handler.syncCommands({
+      application: { commands: { set: async () => [] } },
+    });
+    expect(synced).toBe(true);
+  });
 
-test('withdraw negative amount', () => {
-  reset();
-  initAccount('neg');
-  deposit('neg', 50);
-  assert.throws(() => withdraw('neg', -10));
-  expect(getBalance('neg')).toBe(50);
-});
+  test('economy functions', () => {
+    reset();
+    expect(initAccount('test')).toBe(true);
+    expect(initAccount('test')).toBe(false);
+    deposit('test', 100);
+    expect(getBalance('test')).toBe(100);
+    withdraw('test', 40);
+    expect(getBalance('test')).toBe(60);
+    assert.throws(() => withdraw('test', 100));
+    expect(format(60)).toBe('NT$60');
+  });
 
-test('kanban add', () => {
-  expect(addCard('123', 'test')).toEqual({ text: '123', assign: 'test' });
-});
+  test('withdraw negative amount', () => {
+    reset();
+    initAccount('neg');
+    deposit('neg', 50);
+    assert.throws(() => withdraw('neg', -10));
+    expect(getBalance('neg')).toBe(50);
+  });
 
-test('kanban command', async () => {
-  const result = await handler.execute('kanbanadd', '123', 'test');
-  expect(result).toEqual({ text: '123', assign: 'test' });
-});
+  test('kanban add', () => {
+    expect(addCard('123', 'test')).toEqual({ text: '123', assign: 'test' });
+  });
 
-test('locale error_execute', () => {
-  const en = loadLocale('en');
-  const zh = loadLocale('zh-TW');
-  expect(en('error_execute')).toBe('Error executing command');
-  expect(zh('error_execute')).toBe('執行指令時發生錯誤');
-});
+  test('kanban command', async () => {
+    const result = await handler.execute('kanbanadd', '123', 'test');
+    expect(result).toEqual({ text: '123', assign: 'test' });
+  });
 
-logger.info('All tests passed!');
+  test('locale error_execute', () => {
+    const en = loadLocale('en');
+    const zh = loadLocale('zh-TW');
+    expect(en('error_execute')).toBe('Error executing command');
+    expect(zh('error_execute')).toBe('執行指令時發生錯誤');
+  });
+
+  logger.info('All tests passed!');
+})();


### PR DESCRIPTION
## Summary
- add offline mode for `npm run bot:ci`
- document CI script behavior
- use Discord `/users/@me` endpoint to verify connectivity

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dfcf7a00c832c84bbd138e8468a89